### PR TITLE
EN-11545: Add transform from column names to ids

### DIFF
--- a/src/main/scala/com/socrata/computation_strategies/ComputationStrategy.scala
+++ b/src/main/scala/com/socrata/computation_strategies/ComputationStrategy.scala
@@ -108,9 +108,9 @@ trait ParameterSchema {
   def requiredFields: Seq[String]
 }
 
-trait Augment[T] {
+trait AugmentParameters[T] {
   def augment[ColumnName : JsonDecode : JsonEncode](definition: StrategyDefinition[ColumnName],
-                                                   info: T): Either[ValidationError, StrategyDefinition[ColumnName]]
+                                                    info: T): Either[ValidationError, StrategyDefinition[ColumnName]]
 }
 
 object EitherUtil {

--- a/src/main/scala/com/socrata/computation_strategies/ComputationStrategy.scala
+++ b/src/main/scala/com/socrata/computation_strategies/ComputationStrategy.scala
@@ -66,7 +66,7 @@ trait ComputationStrategy {
   protected def validate[ColumnName : JsonDecode](definition: StrategyDefinition[ColumnName],
                                                   columns: Option[Map[ColumnName, SoQLType]]): Option[ValidationError]
 
-  def transform[CN: JsonDecode, CI : JsonEncode](definition: StrategyDefinition[CN], columns: Map[CN, CI]):
+  def transform[CN : JsonDecode, CI : JsonEncode](definition: StrategyDefinition[CN], columns: Map[CN, CI]):
     Either[ValidationError, StrategyDefinition[CI]] = {
       import EitherUtil._
 
@@ -74,11 +74,11 @@ trait ComputationStrategy {
         sourceColumns <- either(definition.sourceColumns.map(mapOrLeft(_, columns, UnknownSourceColumn(_ : CN)))).right
         parameters <- either(definition.parameters.map(transform(_, columns))).right
       } yield {
-        return Right(StrategyDefinition(definition.typ, sourceColumns, parameters))
+        StrategyDefinition(definition.typ, sourceColumns, parameters)
       }
     }
 
-  protected def transform[CN: JsonDecode, CI : JsonEncode](parameters: JObject, columns: Map[CN, CI]):
+  protected def transform[CN : JsonDecode, CI : JsonEncode](parameters: JObject, columns: Map[CN, CI]):
     Either[ValidationError, JObject] = Right(parameters) // No-op implementation
 }
 
@@ -99,7 +99,7 @@ object ComputationStrategy {
                                         columns: Map[ColumnName, SoQLType]): Option[ValidationError] =
     strategies(definition.typ).validate(definition, columns)
 
-  def transform[CN: JsonDecode, CI : JsonEncode](definition: StrategyDefinition[CN],
+  def transform[CN : JsonDecode, CI : JsonEncode](definition: StrategyDefinition[CN],
                                      columns: Map[CN, CI]): Either[ValidationError, StrategyDefinition[CI]] =
     strategies(definition.typ).transform(definition, columns)
 }

--- a/src/main/scala/com/socrata/computation_strategies/GeocodingComputationStrategy.scala
+++ b/src/main/scala/com/socrata/computation_strategies/GeocodingComputationStrategy.scala
@@ -213,7 +213,7 @@ object GeocodingComputationStrategy extends ComputationStrategy with Augment[Fle
     case None => None
   }
 
-  override protected def transform[CN: JsonDecode, CI : JsonEncode](parameters: JObject, columns: Map[CN, CI]):
+  override protected def transform[CN : JsonDecode, CI : JsonEncode](parameters: JObject, columns: Map[CN, CI]):
     Either[ValidationError, JObject] = {
       import EitherUtil._
 
@@ -232,7 +232,7 @@ object GeocodingComputationStrategy extends ComputationStrategy with Augment[Fle
             } yield {
               val transformed = Some(GeocodingSources[CI](address, locality, subregion, region, postalCode, country))
               // should always be encoded to a JObject
-              return Right(JsonEncode.toJValue(FlexibleGeocodingParameterSchema(transformed, defaults, version)).asInstanceOf[JObject])
+              JsonEncode.toJValue(FlexibleGeocodingParameterSchema(transformed, defaults, version)).asInstanceOf[JObject]
             }
         case Right(_) => Right(parameters) // no source columns to transform
         case Left(DecodeError.MissingField(field, Path.empty)) => Left(MissingParameter(field))

--- a/src/main/scala/com/socrata/computation_strategies/GeocodingComputationStrategy.scala
+++ b/src/main/scala/com/socrata/computation_strategies/GeocodingComputationStrategy.scala
@@ -96,7 +96,7 @@ object FlexibleGeocodingParameterSchema {
  *           "country": "US" },
  *       "version": "v1" }}
  */
-object GeocodingComputationStrategy extends ComputationStrategy with Augment[FlexibleGeocodingDefaults] {
+object GeocodingComputationStrategy extends ComputationStrategy with AugmentParameters[FlexibleGeocodingDefaults] {
 
   val apiVersion = "v1"
   val apiVersions = Set(apiVersion)

--- a/src/test/scala/com/socrata/computation_strategies/ComputationStrategyTest.scala
+++ b/src/test/scala/com/socrata/computation_strategies/ComputationStrategyTest.scala
@@ -1,0 +1,53 @@
+package com.socrata.computation_strategies
+
+import com.socrata.computation_strategies.StrategyType._
+import org.scalatest.{ShouldMatchers, FunSuite}
+
+class ComputationStrategyTest extends FunSuite with ShouldMatchers {
+  import TestData._
+
+  val strategies = StrategyType.allStrategyTypes - Test // Don't care to test Test strategy
+
+  def forStrategyData(test: StrategyData => Unit): Unit = {
+    strategies.foreach { typ =>
+      test(data(typ))
+    }
+  }
+
+  test("Should map strategy types to the correct computation strategy") {
+    val strategies = ComputationStrategy.strategies
+
+    var count = 0
+    def testStrategies(typ: StrategyType, strategy: ComputationStrategy): Unit = {
+      strategies.get(typ) should be (Some(strategy))
+      count += 1
+    }
+
+    testStrategies(GeoRegionMatchOnPoint, GeoRegionMatchOnPointComputationStrategy)
+    testStrategies(GeoRegion, GeoRegionMatchOnPointComputationStrategy)
+    testStrategies(GeoRegionMatchOnString, GeoRegionMatchOnStringComputationStrategy)
+    testStrategies(Geocoding, GeocodingComputationStrategy)
+    testStrategies(Test, TestComputationStrategy)
+
+    strategies.size should be (count) // force people to update this test if they add new strategies
+    strategies.size should be (StrategyType.allStrategyTypes.size)
+  }
+
+  test("Should be able to validate all strategy types") {
+    forStrategyData { data =>
+      ComputationStrategy.validate(data.fullDefinition) should be (None)
+    }
+  }
+
+  test("Should be able to validate all strategy types with column types") {
+    forStrategyData { data =>
+      ComputationStrategy.validate(data.fullDefinition, columnTypes) should be (None)
+    }
+  }
+
+  test("Should be able to transform all strategy types") {
+    forStrategyData { data =>
+      ComputationStrategy.transform(data.fullDefinition, columnIds) should be (data.fullDefinitionTransformed)
+    }
+  }
+}

--- a/src/test/scala/com/socrata/computation_strategies/GeocodingComputationStrategyTest.scala
+++ b/src/test/scala/com/socrata/computation_strategies/GeocodingComputationStrategyTest.scala
@@ -1,0 +1,38 @@
+package com.socrata.computation_strategies
+
+import com.socrata.computation_strategies.GeocodingComputationStrategy.GeocodingSourcesDoNotMatchSourceColumns
+import org.scalatest.{ShouldMatchers, FunSuite}
+
+class GeocodingComputationStrategyTest extends FunSuite with ShouldMatchers {
+  import TestData._
+  import TestData.GeocodingData._
+
+  def testValidate(definition: StrategyDefinition[String], expected: Option[ValidationError] = None): Unit = {
+    GeocodingComputationStrategy.validate(definition) should be (expected)
+  }
+
+  def testTransform(definition: StrategyDefinition[String],
+                    columns: Map[String, Int],
+                    expected: Either[ValidationError, StrategyDefinition[Int]]): Unit = {
+    GeocodingComputationStrategy.transform(definition, columns) should be (expected)
+  }
+
+  test("Definition with full sources and parameters should be invalid") {
+    testValidate(fullDefinition)
+  }
+
+  test("Definition with no sources should be invalid") {
+    val expected = Some(GeocodingSourcesDoNotMatchSourceColumns(List(), Some(GeocodingSources(Some(address),Some(city),
+      Some(county),Some(state),Some(zip),Some(country)))))
+    testValidate(noSourcesDefinition, expected)
+  }
+
+  test("Definition with no parameters should be invalid") {
+    testValidate(noParamsDefinition, Some(MissingParameters(GeocodingParameterSchema)))
+  }
+
+  test("Definition with an unknown source column should fail to transform") {
+    testTransform(fullDefinition, columnIds - address, Left(UnknownSourceColumn(address)))
+  }
+
+}

--- a/src/test/scala/com/socrata/computation_strategies/TestData.scala
+++ b/src/test/scala/com/socrata/computation_strategies/TestData.scala
@@ -1,0 +1,137 @@
+package com.socrata.computation_strategies
+
+import com.rojoma.json.v3.ast.JObject
+import com.rojoma.json.v3.interpolation._
+import com.socrata.computation_strategies.StrategyType.{GeoRegion, GeoRegionMatchOnString, GeoRegionMatchOnPoint, Geocoding}
+import com.socrata.soql.types.{SoQLPoint, SoQLText}
+
+abstract class StrategyData(typ: StrategyType) {
+  protected val strategy = typ
+
+  def fullSources: Seq[String]
+  def fullSourcesTransformed: Seq[Int]
+
+  def fullParameters: JObject
+  def fullParametersTransformed: JObject = fullParameters
+
+  def fullDefinition = definition(Some(fullSources), Some(fullParameters))
+  def fullDefinitionTransformed = Right(definition(Some(fullSourcesTransformed), Some(fullParametersTransformed)))
+
+  def noParamsDefinition = definition(Some(fullSources), None)
+  def noSourcesDefinition: StrategyDefinition[String] = definition(None, Some(fullParameters))
+
+  def definition[T](sourceColumns: Option[Seq[T]], parameters: Option[JObject]) =
+    StrategyDefinition(strategy, sourceColumns, parameters)
+}
+
+object TestData {
+
+  // dataset columns
+
+  // for geocoding
+  val address = "address"
+  val city = "city"
+  val county = "county"
+  val state = "state"
+  val zip = "zip"
+  val country = "country"
+
+  // for region coding
+  val locationPoint = "location_point"
+  val locationString = "location_string"
+
+  val columnTypes = Map(
+    address -> SoQLText,
+    city -> SoQLText,
+    county -> SoQLText,
+    state -> SoQLText,
+    zip -> SoQLText,
+    country -> SoQLText,
+    locationPoint -> SoQLPoint,
+    locationString -> SoQLText
+  )
+
+  val columnIds = Map(
+    address -> 1,
+    city -> 2,
+    county -> 3,
+    state -> 4,
+    zip -> 5,
+    country -> 6,
+    locationPoint -> 7,
+    locationString -> 8
+  )
+
+  object GeocodingData extends StrategyData(Geocoding) {
+
+    override val fullSources = Seq(address, city, county, state, zip, country)
+    override val fullParameters =
+      json"""{ sources:
+               { address: 'address'
+               , locality: 'city'
+               , subregion: 'county'
+               , region: 'state'
+               , postal_code: 'zip'
+               , country: 'country'
+               }
+             , defaults:
+               { address: '705 5th Ave S #600'
+               , locality: 'Seattle'
+               , subregion: 'King'
+               , region: 'WA'
+               , postal_code: '98104'
+               , country: 'US'
+               }
+             , version: 'v1'
+             }""".asInstanceOf[JObject]
+
+    override val fullSourcesTransformed = Seq(1, 2, 3, 4, 5, 6)
+    override val fullParametersTransformed =
+      json"""{ sources:
+               { address: 1
+               , locality: 2
+               , subregion: 3
+               , region: 4
+               , postal_code: 5
+               , country: 6
+               }
+             , defaults:
+               { address: '705 5th Ave S #600'
+               , locality: 'Seattle'
+               , subregion: 'King'
+               , region: 'WA'
+               , postal_code: '98104'
+               , country: 'US'
+               }
+             , version: 'v1'
+             }""".asInstanceOf[JObject]
+  }
+
+  class GeoRegionMatchOnPointData extends StrategyData(GeoRegionMatchOnPoint) {
+    override val fullSources = Seq(locationPoint)
+    override val fullParameters = json"""{ region: '_nmuc-gpu5', primary_key: '_feature_id' }""".asInstanceOf[JObject]
+
+    override val fullSourcesTransformed = Seq(7)
+  }
+
+  val GeoRegionMatchOnPointData = new GeoRegionMatchOnPointData()
+
+  object GeoRegionData extends GeoRegionMatchOnPointData {
+    override protected val strategy = GeoRegion
+  }
+
+  object GeoRegionMatchOnStringData extends StrategyData(GeoRegionMatchOnString) {
+    override val fullSources = Seq(locationString)
+    override val fullParameters = json"""{ region: '_nmuc-gpu5', column: 'column', primary_key: '_feature_id' }""".asInstanceOf[JObject]
+
+    override val fullSourcesTransformed = Seq(8)
+  }
+
+  val data: Map[StrategyType, StrategyData] = Map(
+    Geocoding -> GeocodingData,
+    GeoRegionMatchOnPoint -> GeoRegionMatchOnPointData,
+    GeoRegion -> GeoRegionData,
+    GeoRegionMatchOnString -> GeoRegionMatchOnStringData
+  )
+
+}


### PR DESCRIPTION
 - Add transform(.) function to be used in core
   for transforming a strategy from using column
   names to column ids.
 - Also add augment(.) functions for GeoRegion
   computation strategies.